### PR TITLE
use ztop

### DIFF
--- a/src/DRIVE.F90
+++ b/src/DRIVE.F90
@@ -29,7 +29,8 @@ use DRIVING, only: &
   zaws                ! Weather station elevation for downscaling (m)
 
 use GRID, only: &
-  Nx,Ny               ! Grid dimensions
+  Nx,Ny,             &! Grid dimensions
+  ztop                ! Land surface elevations (m)
 
 use IOUNITS, only: &
   umet                ! Driving file unit number


### PR DESCRIPTION
It seems like `ztop` is not included in the `use` list. I have only compiled this code, but not ran it since the repo lacks an example dem file. If this pr is wrong, just close it.